### PR TITLE
Use cargo feature resolver v2 for better dependency resolving

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[unstable]
+features = ["all"]


### PR DESCRIPTION
This works around https://github.com/matrix-org/matrix-rust-sdk/issues/46 and possibly other issues (you had some issues with wasm-incompatible crates, right?).

Since you're using Nightly anyway, I thought this might be useful. It reduces the number of dependencies on Linux a bit. As an ad-hoc proof of that because I don't actually know how to count transitive dependencies:

```sh
# before
$ cargo tree | wc -l              
740

# after
$ cargo tree | wc -l
717
```